### PR TITLE
chore: correct alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine3.18
+FROM golang:1.23-alpine
 
 COPY ./ /
 RUN cd / && go build


### PR DESCRIPTION
Turns out 1.23 doesn't have alpine 3.18 but 3.20.
Just removing the version setting as this image exists too.

ref: https://github.com/cosmos/cosmos-sdk/actions/runs/10409442143/job/28829251985